### PR TITLE
feat: add Nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ dist/
 /compile_commands.json
 
 .cache/
+
+# nix build result
+result

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,9 @@ LDIR=lib
 IDIR=include
 ODIR=dist
 
-CC=gcc
+PREFIX=/usr
+
+CC?=gcc
 CFLAGS?=-O3
 _CFLAGS=-I$(DIR)
 ALLFLAGS=$(CFLAGS) -I$(IDIR)
@@ -27,13 +29,14 @@ lidm: $(OBJ)
 clean:
 	rm -f $(ODIR)/*.o *- li $(INCDIR)/*-
 
-# Copy lidm to /usr/bin
+# Copy lidm to ${DESTDIR}${PREFIX}/bin (/usr/bin)
 install: lidm
-	install -m755 ./lidm /usr/bin
-	install -m755 ./themes/default.ini /etc/lidm.ini
+	mkdir -p ${DESTDIR}${PREFIX}/bin ${DESTDIR}/etc
+	install -m755 ./lidm ${DESTDIR}${PREFIX}/bin
+	install -m755 ./themes/default.ini ${DESTDIR}/etc/lidm.ini
 
 uninstall:
-	rm -rf /usr/bin/lidm /etc/lidm.ini
+	rm -rf ${DESTDIR}${PREFIX}/bin/lidm ${DESTDIR}/etc/lidm.ini
 
 install-service:
 	@if command -v systemctl &> /dev/null; then \

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1724224976,
+        "narHash": "sha256-Z/ELQhrSd7bMzTO8r7NZgi9g5emh+aRKoCdaAv5fiO0=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "c374d94f1536013ca8e92341b540eba4c22f9c62",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,46 @@
+{
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+  };
+  outputs =
+    { flake-utils, nixpkgs, ... }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+
+        name = "LiDM";
+        version = "0.0.1";
+
+        lidm = (
+          pkgs.stdenv.mkDerivation {
+            pname = name;
+            version = version;
+
+            src = ./.;
+
+            nativeBuildInputs = with pkgs; [
+              gcc
+              gnumake
+              linux-pam
+            ];
+
+            makeFlags = [
+              "DESTDIR=$(out)"
+              "PREFIX="
+            ];
+
+            fixupPhase = ''
+              rm -rf $out/etc
+            '';
+          }
+        );
+      in
+      rec {
+        defaultApp = flake-utils.lib.mkApp { drv = defaultPackage; };
+        defaultPackage = lidm;
+        devShell = pkgs.mkShell { buildInputs = lidm.nativeBuildInputs ++ [ pkgs.clang-tools ]; };
+      }
+    );
+}


### PR DESCRIPTION
Nix build uses GCC but provides clang-tools for development (devShell).

The /etc/lidm.ini is not kept after building though. You may want to add man documentation or make the nix derivation support it...

You can run the package using `nix run`:
```sh
nix run github:javalsai/lidm
```
Adding this to README.md might be useful.