### PR TITLE
Fixes the first two lines in the sha256sum

### DIFF
--- a/assets/pkg/aur/lidm-bin/PKGBUILD
+++ b/assets/pkg/aur/lidm-bin/PKGBUILD
@@ -16,8 +16,8 @@ source=(
     "lidm.1::https://raw.githubusercontent.com/javalsai/lidm/v$pkgver/assets/man/lidm.1"
     "lidm-config.5::https://raw.githubusercontent.com/javalsai/lidm/v$pkgver/assets/man/lidm-config.5"
 )
-sha256sums=('4969018d527613729336abd51e37283ce77d7c7a2233434642804b88e550e622'
-            '27db9b0cd2da80c0c60dcb13dfad0f9d65e7dddbb7b344b859803b9ac3943cd7'
+sha256sums=('65b42f4f7acd970b167fe84d1fa75450b54e01a6f0edddb9d8dd487058a20850'
+            '68662430a6d262b35cc54d9f0e164ed935b7f7f4497a87cc94946c558bbe8a91'
             'a6807a55ff72ec5a5678583156b3efd0d367f0bcb79854094132771f0cb86bce'
             '3adaae60f79dff1cef2b2aba7dcea04196cd49816759ad36afb9f7331ac9c3e4')
 


### PR DESCRIPTION
Change;
sha256sums=('4969018d527613729336abd51e37283ce77d7c7a2233434642804b88e550e622'
            '27db9b0cd2da80c0c60dcb13dfad0f9d65e7dddbb7b344b859803b9ac3943cd7'
            'a6807a55ff72ec5a5678583156b3efd0d367f0bcb79854094132771f0cb86bce'
            '3adaae60f79dff1cef2b2aba7dcea04196cd49816759ad36afb9f7331ac9c3e4')
to;
sha256sums=('65b42f4f7acd970b167fe84d1fa75450b54e01a6f0edddb9d8dd487058a20850'
            '68662430a6d262b35cc54d9f0e164ed935b7f7f4497a87cc94946c558bbe8a91'
            'a6807a55ff72ec5a5678583156b3efd0d367f0bcb79854094132771f0cb86bce'
            '3adaae60f79dff1cef2b2aba7dcea04196cd49816759ad36afb9f7331ac9c3e4')