### PR TITLE
feat: help, version menu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,12 @@ PREFIX=/usr
 CC?=gcc
 CFLAGS?=-O3 -Wall
 _CFLAGS=-I$(DIR)
-ALLFLAGS=$(CFLAGS) -I$(IDIR)
+BUILD_FLAGS=-DLIDM_GIT_DESCRIPTION="\"$(shell git describe --long --tags || echo ?)\"" -DLIDM_BUILD_DATE="\"$(shell date -u +"%Y-%m-%dT%H:%M:%SZ" || echo ?)\""
+ALLFLAGS=$(CFLAGS) -I$(IDIR) $(BUILD_FLAGS)
 
 LIBS=-lpam
 
-_DEPS = log.h util.h ui.h ui_state.h config.h desktop.h auth.h ofield.h efield.h keys.h users.h sessions.h chvt.h macros.h launch_state.h
+_DEPS = version.h log.h util.h ui.h ui_state.h config.h desktop.h auth.h ofield.h efield.h keys.h users.h sessions.h chvt.h macros.h launch_state.h
 DEPS = $(patsubst %,$(IDIR)/%,$(_DEPS))
 
 _OBJ = main.o log.o util.o ui.o ui_state.o config.o desktop.o auth.o ofield.o efield.o users.o sessions.o chvt.o launch_state.o

--- a/include/version.h
+++ b/include/version.h
@@ -1,0 +1,9 @@
+#ifndef LIDM_VERSION
+#define LIDM_VERSION "v1.1.1"
+#endif
+#ifndef LIDM_GIT_DESCRIPTION
+#define LIDM_GIT_DESCRIPTION "?"
+#endif
+#ifndef LIDM_BUILD_DATE
+#define LIDM_BUILD_DATE "?"
+#endif

--- a/src/main.c
+++ b/src/main.c
@@ -1,6 +1,7 @@
 #include <pwd.h>
 #include <stdbool.h>
 #include <stdio.h>
+#include <string.h>
 #include <sys/ioctl.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -12,6 +13,7 @@
 #include "ui.h"
 #include "users.h"
 #include "util.h"
+#include "version.h"
 
 int main(int argc, char* argv[]) {
   // Logger
@@ -27,8 +29,23 @@ int main(int argc, char* argv[]) {
     log_init(log_fd);
   }
 
-  // Chvt
-  if (argc == 2) chvt_str(argv[1]);
+  if (argc == 2) {
+    if (strcmp(argv[1], "-v") == 0 || strcmp(argv[1], "--version") == 0) {
+      printf("lidm version %s (git %s, build date %s)\n", LIDM_VERSION,
+             LIDM_GIT_DESCRIPTION, LIDM_BUILD_DATE);
+      return 0;
+    } else if (strcmp(argv[1], "-h") == 0 || strcmp(argv[1], "--help") == 0) {
+      printf(
+          "Usage: lidm [vt number]\n"
+          "Options:\n"
+          "  -h, --help     Display help menu\n"
+          "  -v, --version  Display version information\n");
+      return 0;
+    } else {
+      // Chvt
+      chvt_str(argv[1]);
+    }
+  }
 
   struct config config = DEFAULT_CONFIG;
   char* conf_override = getenv("LIDM_CONF");


### PR DESCRIPTION
git describe and build date are optional but could help debugging issues of other people.

`LIDM_VERSION` is currently hard-coded, I thought about two solutions:
1. Bump the version manually in a commit before tagging new release
2. Use github commit action to create the bump commit before (?) releasing

This is how it looks like:
```
$ ./lidm -h
Usage: lidm [vt number]
Options:
  -h, --help     Display help menu
  -v, --version  Display version information
```
```
$ ./lidm -v
lidm version v1.1.1 (git v1.1.1-6-gafd2365, build date 2025-07-03T22:19:08Z)
```