### PR TITLE
build: preparations for musl

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,8 @@ jobs:
             apt-get update && \
             apt-get install -y make gcc libpam0g-dev
           run: ARCH=aarch64 GITHUB_STEP_SUMMARY=gss.out GITHUB_OUTPUT=go.out assets/github_scripts/build.sh
-      - run: set +e; cat gss.out >>"$GITHUB_STEP_SUMMARY"; cat go.out >>"$GITHUB_OUTPUT"
+      - if: always()
+        run: set +e; cat gss.out >>"$GITHUB_STEP_SUMMARY"; cat go.out >>"$GITHUB_OUTPUT"
 
       - uses: actions/upload-artifact@v4
         with:
@@ -94,7 +95,8 @@ jobs:
             apt-get update && \
             apt-get install -y make gcc libpam0g-dev
           run: ARCH=armv7 GITHUB_STEP_SUMMARY=gss.out GITHUB_OUTPUT=go.out assets/github_scripts/build.sh
-      - run: set +e; cat gss.out >>"$GITHUB_STEP_SUMMARY"; cat go.out >>"$GITHUB_OUTPUT"
+      - if: always()
+        run: set +e; cat gss.out >>"$GITHUB_STEP_SUMMARY"; cat go.out >>"$GITHUB_OUTPUT"
 
       - uses: actions/upload-artifact@v4
         with:
@@ -121,10 +123,39 @@ jobs:
             apt-get update && \
             apt-get install -y make gcc libpam0g-dev
           run: ARCH=riscv64 GITHUB_STEP_SUMMARY=gss.out GITHUB_OUTPUT=go.out assets/github_scripts/build.sh
-      - run: set +e; cat gss.out >>"$GITHUB_STEP_SUMMARY"; cat go.out >>"$GITHUB_OUTPUT"
+      - if: always()
+        run: set +e; cat gss.out >>"$GITHUB_STEP_SUMMARY"; cat go.out >>"$GITHUB_OUTPUT"
 
       - uses: actions/upload-artifact@v4
         with:
           name: build-riscv64
           path: lidm-riscv64
+          retention-days: 1
+
+  build-linux-amd64-musl:
+    name: amd64-musl
+    runs-on: ubuntu-24.04
+    permissions: write-all
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run in Musl Container
+        uses: addnab/docker-run-action@v3
+        with:
+          image: ghcr.io/void-linux/void-musl-full
+          options: -v ${{ github.workspace }}:/workspace
+          run: |
+            cd /workspace
+
+            xbps-install -Sy
+            xbps-install -y git pam-devel make gcc bash git
+
+            ARCH=amd64-musl GITHUB_STEP_SUMMARY=gss.out GITHUB_OUTPUT=go.out assets/github_scripts/build.sh
+      - if: always()
+        run: set +e; cat gss.out >>"$GITHUB_STEP_SUMMARY"; cat go.out >>"$GITHUB_OUTPUT"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: build-amd64-musl
+          path: lidm-amd64-musl
           retention-days: 1

--- a/include/util.h
+++ b/include/util.h
@@ -1,11 +1,11 @@
 #ifndef UTILH_
 #define UTILH_
 
-#include <bits/types/struct_timeval.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <sys/time.h>
 #include <sys/types.h>
 
 #include "keys.h"

--- a/src/auth.c
+++ b/src/auth.c
@@ -245,7 +245,7 @@ bool launch(char* user, char* passwd, struct session session, void (*cb)(void),
     perror("execl error");
     (void)fputs("failure calling session\n", stderr);
   } else {
-    __pid_t child_pid = (__pid_t)pid;
+    pid_t child_pid = (pid_t)pid;
     waitpid(child_pid, NULL, 0);
 
     pam_setcred(pamh, PAM_DELETE_CRED);


### PR DESCRIPTION
This PR makes it possible to *build* using musl libc. **The application functionality not been tested yet.** I won't test it myself, but it should work.

Fixes [Void Linux package CI errors](https://github.com/void-linux/void-packages/actions/runs/16179578824/job/45674351752).