### PR TITLE
feat(PAM service configuration)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ LiDM is like any [Display Manager](https://en.wikipedia.org/wiki/X_display_manag
 - [Installation](#installation)
 - [Configuring](#configuring)
 - [PAM](#pam)
+  - [Packagers - look here!](#packagers---look-here)
 - [Contributing](#contributing)
 - [Inspiration](#inspiration)
 - [Contributors](#contributors)
@@ -92,9 +93,13 @@ Colors are gonna be put inside `\x1b[...m`, if you don't know what this is check
 
 # PAM
 
-If your distro does not use the standard PAM service name `login` (`/etc/pam.d/login`) for its PAM services or if you want to use another PAM file, simply set the `LIDM_PAM_SERVICE` env variable to your PAM service name. 
+If your distribution does not use the standard PAM service name `login` (`/etc/pam.d/login`) for its PAM services or if you want to use another PAM file, simply set the `LIDM_PAM_SERVICE` env variable to your PAM service name. 
 
-When the env variable is empty it defaults to the `login` PAM service.
+When the env variable is empty it defaults to the `login` PAM service or whatever fallback your distribution packager has defined during compilation.
+
+## Packagers - look here!
+
+If you distribution has a standard service that you want to use as a fallback value (by default) then you can define it using the -DPAM_SERVICE_FALLBACK C Pre-processor flag, eg: `make 'CPPFLAGS+=-DPAM_SERVICE_FALLBACK="fallbackvalue"'`.
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -23,20 +23,20 @@ LiDM is like any [Display Manager](https://en.wikipedia.org/wiki/X_display_manag
 
 # Index
 
-* [LiDM](#lidm)
-  * [Features](#features)
-  * [WIP](#wip)
-* [Index](#index)
-* [Ideology](#ideology)
-* [Usage](#usage)
-  * [Arguments](#arguments)
-  * [Program](#program)
-* [Requirements](#requirements)
-* [Installation](#installation)
-* [Configuring](#configuring)
-* [Contributing](#contributing)
-* [Inspiration](#inspiration)
-* [Contributors](#contributors)
+- [LiDM](#lidm)
+  - [Features](#features)
+- [Index](#index)
+- [Ideology](#ideology)
+- [Usage](#usage)
+    - [Arguments](#arguments)
+    - [Program](#program)
+- [Requirements](#requirements)
+- [Installation](#installation)
+- [Configuring](#configuring)
+- [PAM](#pam)
+- [Contributing](#contributing)
+- [Inspiration](#inspiration)
+- [Contributors](#contributors)
 
 # Ideology
 
@@ -89,6 +89,12 @@ Colors are gonna be put inside `\x1b[...m`, if you don't know what this is check
 
 > [!TIP]
 > If you don't like seeing an element, you can change the fg color of it to be the same as the bg, making it invisible.
+
+# PAM
+
+If your distro does not use the standard PAM service name `login` (`/etc/pam.d/login`) for its PAM services or if you want to use another PAM file, simply set the `LIDM_PAM_SERVICE` env variable to your PAM service name. 
+
+When the env variable is empty it defaults to the `login` PAM service.
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ LiDM is like any [Display Manager](https://en.wikipedia.org/wiki/X_display_manag
 - [Installation](#installation)
 - [Configuring](#configuring)
 - [PAM](#pam)
-  - [Packagers - look here!](#packagers---look-here)
 - [Contributing](#contributing)
 - [Inspiration](#inspiration)
 - [Contributors](#contributors)
@@ -96,10 +95,6 @@ Colors are gonna be put inside `\x1b[...m`, if you don't know what this is check
 If your distribution does not use the standard PAM service name `login` (`/etc/pam.d/login`) for its PAM services or if you want to use another PAM file, simply set the `LIDM_PAM_SERVICE` env variable to your PAM service name. 
 
 When the env variable is empty it defaults to the `login` PAM service or whatever fallback your distribution packager has defined during compilation.
-
-## Packagers - look here!
-
-If you distribution has a standard service that you want to use as a fallback value (by default) then you can define it using the -DPAM_SERVICE_FALLBACK C Pre-processor flag, eg: `make 'CPPFLAGS+=-DPAM_SERVICE_FALLBACK="fallbackvalue"'`.
 
 # Contributing
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -2,9 +2,10 @@
 
 Contributions are welcome! Here's how you can help:
 
-* [Contributing code](#code)
-* [Reporting issues](#issues)
-* [Other](#other)
+- [Contributing](#contributing)
+  - [Code](#code)
+  - [Issues](#issues)
+  - [Other](#other)
 
 ## Code
 
@@ -18,7 +19,7 @@ For small fixes or incremental improvements simply fork the repo and follow the 
    * Check your code works as expected.
    * Run the code formatter: `clang-format -i $(git ls-files "*.c" "*.h")`
    * Run the code linter: `clang-tidy -p . $(git ls-files "*.c" "*.h")`. Some checks are pretty pedantic, feel free to ignore or debate some of the rules.
-   * If you prefer, you can run `make pre-commit` to run several code style checks like the avobe along a few extra stuff.
+   * If you prefer, you can run `make pre-commit` to run several code style checks like the above along a few extra stuff.
 
 3. Commit your changes to a new branch (not `master`, one change per branch) and push it:
    * Commit messages should:

--- a/src/auth.c
+++ b/src/auth.c
@@ -35,10 +35,6 @@ int pam_conversation(int num_msg, const struct pam_message** msg,
   return PAM_SUCCESS;
 }
 
-#ifndef PAM_SERVICE_NAME
-#define PAM_SERVICE_NAME "login"
-#endif
-
 #define CHECK_PAM_RET(call) \
   ret = (call);             \
   if (ret != PAM_SUCCESS) { \
@@ -55,7 +51,11 @@ pam_handle_t* get_pamh(char* user, char* passwd) {
   struct pam_conv pamc = {pam_conversation, (void*)passwd};
   int ret;
 
-  CHECK_PAM_RET(pam_start(PAM_SERVICE_NAME, user, &pamc, &pamh))
+  char* pam_service_name_env = getenv("LIDM_PAM_SERVICE");
+  char* pam_service_name =
+      pam_service_name_env != NULL ? pam_service_name_env : "login";
+
+  CHECK_PAM_RET(pam_start(pam_service_name, user, &pamc, &pamh))
   CHECK_PAM_RET(pam_authenticate(pamh, 0))
   CHECK_PAM_RET(pam_acct_mgmt(pamh, 0))
   CHECK_PAM_RET(pam_setcred(pamh, PAM_ESTABLISH_CRED))

--- a/src/auth.c
+++ b/src/auth.c
@@ -35,6 +35,10 @@ int pam_conversation(int num_msg, const struct pam_message** msg,
   return PAM_SUCCESS;
 }
 
+#ifndef PAM_SERVICE_NAME
+#define PAM_SERVICE_NAME "login"
+#endif
+
 #define CHECK_PAM_RET(call) \
   ret = (call);             \
   if (ret != PAM_SUCCESS) { \
@@ -51,7 +55,7 @@ pam_handle_t* get_pamh(char* user, char* passwd) {
   struct pam_conv pamc = {pam_conversation, (void*)passwd};
   int ret;
 
-  CHECK_PAM_RET(pam_start("login", user, &pamc, &pamh))
+  CHECK_PAM_RET(pam_start(PAM_SERVICE_NAME, user, &pamc, &pamh))
   CHECK_PAM_RET(pam_authenticate(pamh, 0))
   CHECK_PAM_RET(pam_acct_mgmt(pamh, 0))
   CHECK_PAM_RET(pam_setcred(pamh, PAM_ESTABLISH_CRED))

--- a/src/auth.c
+++ b/src/auth.c
@@ -35,6 +35,10 @@ int pam_conversation(int num_msg, const struct pam_message** msg,
   return PAM_SUCCESS;
 }
 
+#ifndef PAM_SERVICE_FALLBACK
+#define PAM_SERVICE_FALLBACK "login"
+#endif
+
 #define CHECK_PAM_RET(call) \
   ret = (call);             \
   if (ret != PAM_SUCCESS) { \
@@ -51,9 +55,9 @@ pam_handle_t* get_pamh(char* user, char* passwd) {
   struct pam_conv pamc = {pam_conversation, (void*)passwd};
   int ret;
 
-  char* pam_service_name_env = getenv("LIDM_PAM_SERVICE");
+  char* pam_service_override = getenv("LIDM_PAM_SERVICE");
   char* pam_service_name =
-      pam_service_name_env != NULL ? pam_service_name_env : "login";
+      pam_service_override ? pam_service_override : PAM_SERVICE_FALLBACK;
 
   CHECK_PAM_RET(pam_start(pam_service_name, user, &pamc, &pamh))
   CHECK_PAM_RET(pam_authenticate(pamh, 0))

--- a/src/desktop.c
+++ b/src/desktop.c
@@ -66,8 +66,7 @@ int read_desktop(FILE* fd, void* ctx,
       buf_start[eq_idx] = '\0'; // the equal
       key = trim_str(key);
       char* value = &buf_start[eq_idx + 1];
-      if(buf_start[read_size - 1] == '\n')
-        buf_start[read_size - 1] = '\0';
+      if (buf_start[read_size - 1] == '\n') buf_start[read_size - 1] = '\0';
       value = trim_str(value);
 
       // Callback


### PR DESCRIPTION
## What I've done:
- Fixed a small typo in the contributions guide
- Added ENV variable configuration for the PAM service name, fallbacks to our previously hardcoded `login`

## Notes

From the limited testing that I've been able to do this works perfectly.

This also solves issue #58 

**// SpamixOffcial 16/7-25**