### PR TITLE
Several fixes for trunc_gethostname

### DIFF
--- a/include/util.h
+++ b/include/util.h
@@ -19,6 +19,7 @@ bool read_press_nb(u_char* length, char* out, struct timeval* tv);
 bool utf8_iscont(char byte);
 size_t utf8len(const char* str);
 size_t utf8len_until(const char* str, const char* until);
+size_t utf8trunc(char* str, size_t n);
 const char* utf8back(const char* str);
 const char* utf8seek(const char* str);
 const char* utf8seekn(const char* str, size_t n);

--- a/src/util.c
+++ b/src/util.c
@@ -103,6 +103,24 @@ size_t utf8len_until(const char* str, const char* until) {
   return len;
 }
 
+size_t utf8trunc(char* str, size_t n) {
+  size_t bytes = 0;
+  while (true) {
+    if(str[bytes] == '\0') break;
+    if (utf8_iscont(str[bytes])) {
+      bytes++;
+      continue;
+    }
+    if(n == 0) {
+      str[bytes] = '\0';
+      break;
+    }
+    bytes++;
+    n--;
+  }
+  return bytes;
+}
+
 const char* utf8back(const char* str) {
   while (utf8_iscont(*(--str))) {
   }


### PR DESCRIPTION
## Problem

Buffer overflow in `buf` with `strcpy` in case `ELLIPSIS` is a multi-byte character
```cpp
      if (utf8len(buf) > MAXSIZE - utf8len(ELLIPSIS)) {
        strcpy(&buf[MAXSIZE - utf8len(ELLIPSIS)], ELLIPSIS);
        return buf;
      }
```

## Changes

- `trunc_gethostname` was completely re-written
- Additional helper function `utf8trunc`
- Hostname buffer is now fixed to `HOST_NAME_MAX` instead of growing