### PR TITLE
fix(nix): no longer trying to access non existent attribute

### DIFF
--- a/assets/pkg/nix/lidm.nix
+++ b/assets/pkg/nix/lidm.nix
@@ -38,7 +38,7 @@ pkgs.stdenv.mkDerivation rec {
     ++ lib.optional (
       config.wayland-sessions != null
     ) "CPPFLAGS+=-DSESSIONS_WAYLAND=\\\"${config.wayland-sessions}\\\""
-    ++ lib.optional (cfg-file != null) "CPPFLAGS+=-DLIDM_CONF_PATH=\\\"${cfg-file}\\\"";
+    ++ lib.optional (get-cfg != null) "CPPFLAGS+=-DLIDM_CONF_PATH=\\\"${cfg-file}\\\"";
 
   fixupPhase = ''
     rm -rf $out/etc


### PR DESCRIPTION
fixes the nix build. `cfg-file` doesn't exist if `get-cfg` is null, so checking if `get-cfg` is null instead of `cfg-file`