### PR TITLE
fix systemd service install recipe, restart systemd service on session quit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ install-service:
 	fi
 
 install-service-systemd:
-	install -m644 ./assets/services/systemd.service ${DESTDIR}/usr/local/lib/systemd/system/lidm.service
+	install -Dm644 ./assets/services/systemd.service ${DESTDIR}/usr/local/lib/systemd/system/lidm.service
 	@printf '\033[1m%s\033[0m\n\n' " don't forget to run 'systemctl enable lidm'"
 install-service-dinit:
 	install -m644 ./assets/services/dinit ${DESTDIR}/etc/dinit.d/lidm

--- a/assets/services/systemd.service
+++ b/assets/services/systemd.service
@@ -11,6 +11,7 @@ StandardError=tty
 TTYPath=/dev/tty7
 TTYReset=yes
 TTYVHangup=yes
+Restart=always
 
 [Install]
 Alias=display-manager.service


### PR DESCRIPTION
1. address #81
2. `/usr/local/lib/systemd` doesn't exist by default on most distros, which means that unless it's been explicitly created, the `install-service-systemd` recipe fails. there's a really simple fix for this, namely the `-D` flag on `install`, which does the same thing as `-p` on the `mkdir` command. (oftentimes, people will do `install -D` for every single install command in the makefile, precisely because it avoids this kind of error)

(this time actually on a separate branch with the changes pushed)
